### PR TITLE
Claude

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -7,21 +7,31 @@ const MAX_ROWS = 25;
 type PrimaryDataType = "issue" | "commit" | "pull-request" | "snippet" | "item";
 type GridCellState = "empty" | "generating" | "done";
 
+export type ColumnType = "text" | "single-select" | "multi-select";
+
+export type Option = {
+  title: string;
+  description: string;
+};
+
 export type GridCell = {
   state: GridCellState;
   columnTitle: string;
   columnInstructions: string;
-  displayValue: string;
+  displayValue: string | string[];
   context: any;
   hydrationSources: string[];
+  columnType: ColumnType;
+  options?: Option[];
 };
 
 export type GridCol = {
   title: string;
   instructions: string;
+  type: ColumnType;
+  options?: Option[];
   cells: GridCell[];
 };
-
 export type GridPrimaryCell = {
   context: any;
   displayValue: string;
@@ -141,11 +151,15 @@ export async function hydrateCell(cell: GridCell): Promise<HydrateResponse> {
   You will receive a user message that contains two things:\n
   1) Context: A JSON object representing some artifact from GitHub.com. It could be an issue, pull request, commit, file, etc
   2) Query: A user-provided query that describes a question that you should answer using the provided artifact\n
-  In some cases, the JSON object itself will contain the answer.  In other cases, you will need to use a single tool or a sequence of tools to find the answer.\
-  The user interface is not a conversational chat interface, so you should avoid introductions, goodbyes, or any other pleasentries. It's critical that you provide the answer as concisely as possible.
+  In some cases, the JSON object itself will contain the answer. In other cases, you will need to use a single tool or a sequence of tools to find the answer.\
+  The user interface is not a conversational chat interface, so you should avoid introductions, goodbyes, or any other pleasantries. It's critical that you provide the answer as concisely as possible.
 
-  Markdown rendering is supported, but use it lightly. Only use lists, bold, italics, links. Never use headings.\
-`;
+  If the column type is "text", provide your answer as a concise markdown string.
+  If the column type is "single-select", choose the most appropriate option from the provided list and return only its title.
+  If the column type is "multi-select", choose all appropriate options from the provided list and return an array of their titles.
+
+  Markdown rendering is supported for text columns, but use it lightly. Only use lists, bold, italics, links. Never use headings.\
+  `;
 
   async function hydrate(): Promise<GridCell> {
     let hydrationSources: string[] = [];
@@ -156,6 +170,8 @@ export async function hydrateCell(cell: GridCell): Promise<HydrateResponse> {
         content: `
         Context: ${JSON.stringify(cell.context)}
         Query: ${cell.columnTitle}\n${cell.columnInstructions}
+        Column Type: ${cell.columnType}
+        ${cell.options ? `Options: ${JSON.stringify(cell.options)}` : ''}
       `,
       },
     ];
@@ -194,12 +210,19 @@ export async function hydrateCell(cell: GridCell): Promise<HydrateResponse> {
     await run();
 
     const assistantResponse = context[context.length - 1].content as string;
-
+    let displayValue: string | string[];
+    if (cell.columnType === "single-select") {
+      displayValue = assistantResponse as string;
+    } else if (cell.columnType === "multi-select") {
+      displayValue = JSON.parse(assistantResponse as string) as string[];
+    } else {
+      displayValue = assistantResponse as string;
+    }
     return {
       ...cell,
       state: "done",
       hydrationSources,
-      displayValue: assistantResponse,
+      displayValue,
     };
   }
 

--- a/app/components/GridCell.tsx
+++ b/app/components/GridCell.tsx
@@ -1,16 +1,24 @@
-import { Box } from "@primer/react";
+import React from "react";
+import { Box, Label } from "@primer/react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { ColumnType } from "../actions";
+
+type GridCellProps = {
+  sx?: any;
+  children: React.ReactNode;
+  onClick?: () => void;
+  isSelected?: boolean;
+  columnType: ColumnType;
+};
 
 export default function GridCell({
   sx,
   children,
   onClick,
   isSelected = false,
-}: {
-  sx?: any;
-  children: React.ReactNode;
-  onClick?: () => void;
-  isSelected?: boolean;
-}) {
+  columnType,
+}: GridCellProps) {
   const hoverProps = onClick
     ? {
         ":hover": {
@@ -23,6 +31,27 @@ export default function GridCell({
   const selectedProps = {
     backgroundColor: "canvas.inset",
   };
+
+  const renderContent = () => {
+    if (columnType === "text") {
+      return (
+        <Markdown remarkPlugins={[remarkGfm]} className="markdownContainer">
+          {children as string}
+        </Markdown>
+      );
+    } else if (columnType === "single-select") {
+      return <Label>{children as string}</Label>;
+    } else if (columnType === "multi-select") {
+      return (
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+          {(children as string[]).map((option, index) => (
+            <Label key={index}>{option}</Label>
+          ))}
+        </Box>
+      );
+    }
+  };
+
   return (
     <Box
       sx={{
@@ -36,7 +65,6 @@ export default function GridCell({
         fontSize: 1,
         boxSizing: "border-box",
         minWidth: "var(--cell-width)",
-        //maxWidth: "640px",
         height: "var(--cell-height)",
         borderBottom: "1px solid",
         borderColor: "border.default",
@@ -50,7 +78,7 @@ export default function GridCell({
       }}
       onClick={onClick}
     >
-      {children}
+      {renderContent()}
     </Box>
   );
 }

--- a/app/components/GridTable.tsx
+++ b/app/components/GridTable.tsx
@@ -26,12 +26,12 @@ export function PrimaryColumn({
       <ColumnTitle title={title} />
       {primaryColumn.map((cell: GridPrimaryCell, cellIndex: number) => (
         <GridCell
+          key={cellIndex}
           isSelected={selectedIndex === cellIndex}
-          onClick={() => {
-            selectRow(cellIndex);
-          }}
+          onClick={() => selectRow(cellIndex)}
+          columnType="text" // Assuming primary column is always text
         >
-          <Box sx={{ fontWeight: "semibold" }}>{cell.displayValue}</Box>
+          {typeof cell.displayValue === 'string' ? cell.displayValue : JSON.stringify(cell.displayValue)}
         </GridCell>
       ))}
     </Column>
@@ -175,6 +175,7 @@ export default function GridTable() {
                 {column.cells.map((cell, cellIndex: number) => (
                   <GridCell
                     key={cellIndex}
+                    columnType={column.type}
                     isSelected={selectedIndex === cellIndex}
                   >
                     {cell.state === "done" ? (

--- a/app/components/NewColumnForm.tsx
+++ b/app/components/NewColumnForm.tsx
@@ -1,14 +1,24 @@
-import { useState } from "react";
-import { Box, Button, TextInput, Textarea, FormControl } from "@primer/react";
-import GridCell from "./GridCell";
+import React, { useState } from "react";
+import { Box, Button, TextInput, Textarea, FormControl, Select, Label } from "@primer/react";
+
+type ColumnType = "text" | "single-select" | "multi-select";
+
+type Option = {
+  title: string;
+  description: string;
+};
 
 type Props = {
   addNewColumn: ({
     title,
     instructions,
+    type,
+    options,
   }: {
     title: string;
     instructions: string;
+    type: ColumnType;
+    options: Option[];
   }) => void;
   errorMessage?: string;
 };
@@ -16,68 +26,103 @@ type Props = {
 export default function NewColumnForm({ addNewColumn, errorMessage }: Props) {
   const [title, setTitle] = useState<string>("");
   const [instructions, setInstructions] = useState<string>("");
-  const [message, setMessage] = useState<string>(
-    errorMessage ? errorMessage : "",
-  );
-  function addNewHandler(e: any) {
+  const [type, setType] = useState<ColumnType>("text");
+  const [options, setOptions] = useState<Option[]>([]);
+  const [message, setMessage] = useState<string>(errorMessage || "");
+
+  const addOption = () => {
+    setOptions([...options, { title: "", description: "" }]);
+  };
+
+  const updateOption = (index: number, field: keyof Option, value: string) => {
+    const newOptions = [...options];
+    newOptions[index][field] = value;
+    setOptions(newOptions);
+  };
+
+  const removeOption = (index: number) => {
+    setOptions(options.filter((_, i) => i !== index));
+  };
+
+  function addNewHandler(e: React.FormEvent) {
     e.preventDefault();
     setMessage("");
 
     if (title === "") {
-      setMessage("enter a value");
+      setMessage("Enter a title");
       return;
     }
 
-    addNewColumn({ title, instructions });
+    if ((type === "single-select" || type === "multi-select") && options.length === 0) {
+      setMessage("Add at least one option for select types");
+      return;
+    }
+
+    addNewColumn({ title, instructions, type, options });
     setTitle("");
     setInstructions("");
-    return false;
+    setType("text");
+    setOptions([]);
   }
 
   return (
-    <Box>
-      <Box sx={{}}>
-        {message && <div className="error-message">{message}</div>}
-        <Box
-          as="form"
-          sx={{ gap: 3, display: "flex", flexDirection: "column" }}
-          onSubmit={addNewHandler}
-        >
-          <FormControl>
-            <FormControl.Label>Title</FormControl.Label>
-            <TextInput
-              type="text"
-              value={title}
-              block={true}
-              onChange={(e) => setTitle(e.target.value)}
-            />
-            <FormControl.Caption>
-              Will be included in prompt
-            </FormControl.Caption>
-          </FormControl>
+    <Box as="form" sx={{ gap: 3, display: "flex", flexDirection: "column" }} onSubmit={addNewHandler}>
+      {message && <Box sx={{ color: "danger.fg" }}>{message}</Box>}
+      
+      <FormControl>
+        <FormControl.Label>Title</FormControl.Label>
+        <TextInput
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          block
+        />
+      </FormControl>
 
-          <FormControl>
-            <FormControl.Label>Instructions</FormControl.Label>
-            <Textarea
-              placeholder="Describe how this field should be populated..."
-              value={instructions}
-              block={true}
-              rows={24}
-              onChange={(e) => setInstructions(e.target.value)}
-            />
-            <FormControl.Caption>
-              Optional but recommended. Add detailed instructions about how the
-              column should render.
-            </FormControl.Caption>
-          </FormControl>
+      <FormControl>
+        <FormControl.Label>Type</FormControl.Label>
+        <Select value={type} onChange={(e) => setType(e.target.value as ColumnType)}>
+          <Select.Option value="text">Text</Select.Option>
+          <Select.Option value="single-select">Single Select</Select.Option>
+          <Select.Option value="multi-select">Multi Select</Select.Option>
+        </Select>
+      </FormControl>
 
-          <Box sx={{ display: "flex", gap: 2, justifyContent: "flex-end" }}>
-            <Button onClick={addNewHandler}>Cancel</Button>
-            <Button variant="primary" onClick={addNewHandler}>
-              Submit
-            </Button>
-          </Box>
+      {(type === "single-select" || type === "multi-select") && (
+        <Box>
+          <FormControl.Label>Options</FormControl.Label>
+          {options.map((option, index) => (
+            <Box key={index} sx={{ display: "flex", gap: 2, mb: 2 }}>
+              <TextInput
+                placeholder="Title"
+                value={option.title}
+                onChange={(e) => updateOption(index, "title", e.target.value)}
+              />
+              <TextInput
+                placeholder="Description"
+                value={option.description}
+                onChange={(e) => updateOption(index, "description", e.target.value)}
+              />
+              <Button onClick={() => removeOption(index)}>Remove</Button>
+            </Box>
+          ))}
+          <Button onClick={addOption}>Add Option</Button>
         </Box>
+      )}
+
+      <FormControl>
+        <FormControl.Label>Instructions</FormControl.Label>
+        <Textarea
+          value={instructions}
+          onChange={(e) => setInstructions(e.target.value)}
+          placeholder="Describe how this field should be populated..."
+          rows={6}
+          block
+        />
+      </FormControl>
+
+      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+        <Button type="submit" variant="primary">Submit</Button>
       </Box>
     </Box>
   );

--- a/app/components/SelectedContext.tsx
+++ b/app/components/SelectedContext.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
-import { IconButton, Box, Tooltip } from "@primer/react";
+import { IconButton, Box, Label } from "@primer/react";
 import {
   XIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   ChevronRightIcon,
 } from "@primer/octicons-react";
-import { GridCol, GridCell } from "../actions";
+import { GridCol, GridCell, ColumnType} from "../actions";
 import { useGridContext } from "./GridContext";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -136,6 +136,30 @@ function CellValue({
 }) {
   const sources = cell.hydrationSources;
 
+  const renderCellContent = (type: ColumnType, value: string | string[]) => {
+    switch (type) {
+      case "text":
+        return (
+          <Markdown remarkPlugins={[remarkGfm]} className="markdownContainer">
+            {value as string}
+          </Markdown>
+        );
+      case "single-select":
+        return <Label>{value as string}</Label>;
+      case "multi-select":
+        return (
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+            {(value as string[]).map((option, index) => (
+              <Label key={index}>{option}</Label>
+            ))}
+          </Box>
+        );
+      default:
+        return String(value); // Fallback to string representation
+    }
+  };
+
+
   return (
     <Box
       sx={{
@@ -170,9 +194,7 @@ function CellValue({
       </Box>
 
       <Box sx={{ p: 3, gap: 3 }}>
-        <Markdown remarkPlugins={[remarkGfm]} className="markdownContainer">
-          {cell.displayValue || ""}
-        </Markdown>
+        {renderCellContent(column.type, cell.displayValue)}
         <Prompt prompt={`${column.title}\n${column.instructions}`} />
       </Box>
     </Box>


### PR DESCRIPTION
Please help me with a refactor of this application.  Here are the requirements.

Current context:
Right now, when adding a new column, the only "type" supported is a text type. When adding a text type column, the user describes how the text should be generated through an instruction field.  When the column is created and ultimately rendered, the column renders markdown text provided by an OpenAI language model completion.

Proposed changes:
We wish to update the column behavior so that users can select one of 3 potential column types:
* Text (the current behavior)
* Single select
* Multi select

When either Single select or Multi select are selected, the user will need to define a list of options. Each option contains a title and description. The users column type selection and option schemas must be provided to the actions handler.  The type and options schemas must be provided to the language model completion and we must ensure that the language model replies in a format that aligns with the column type.

A good example use case here is in issue triaging. Users may wish to create columns for "Issue Tags" that is a multi select field. The user could define tags such as "BUG", "FEATURE", "ACCESSIBILITY", or "BACKEND".  These tags would automatically be inferred from the contents of the relevant context from the primary column.

Once the column data is hydrated, we should render cells differently based on the column type. If the column is a Single or Multi select, render the values within a label component: <Label>Option</Label>

Please write entire files. I will save them to my editor and then reply with any feedback from static analysis or from running the changes that you propose